### PR TITLE
Upgrade: From 3.7.x to 3.9.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:3.7.17-management
+FROM rabbitmq:3.9.18-management
 
 COPY rabbitmq.conf /etc/rabbitmq/
 


### PR DESCRIPTION
At this moment, 3.10.x has been out for < 1 month. 3.9.x therefore gives
us a longer-running minor version.

Upgrading from 3.7.x keeps us more up-to-date, and gives us built in
Prometheus support (introduced in 3.8.x).